### PR TITLE
Update CMAKE_BUILD_TYPE flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ Summary: JIGSAW is a Delaunay-based unstructured mesh generator for two- and
 three-dimensional geometries.
 
 
-`JIGSAW` is an unstructured mesh generator and tessellation library; designed 
-to generate high-quality triangulations and polyhedral decompositions of general 
-planar, surface and volumetric domains. `JIGSAW` includes refinement-based 
-algorithms for the construction of new meshes, optimisation-driven techniques 
-for the improvement of existing grids, as well as routines to assemble 
-(restricted) Delaunay tessellations, Voronoi complexes and Power diagrams. 
+JIGSAW is a computational library for unstructured mesh generation and
+tessellation; designed to generate high-quality triangulations and
+polyhedral decompositions of general planar, surface and volumetric
+domains. JIGSAW includes refinement-based algorithms for the construction
+of new meshes, optimisation-driven techniques for the improvement of
+existing grids, as well as routines to assemble (restricted) Delaunay
+tessellations and Voronoi complexes.
 
-This package provides the underlying `c++` source for `JIGSAW`; defining a basic 
-command-line interface and a `c`-format `API`. Higher-level scripting interfaces, 
-supporting a range of additional facilities for file I/O, mesh visualisation and 
-post-processing operations are also available, including for 
-`MATLAB` / `OCTAVE` <a href="https://github.com/dengwirda/jigsaw-matlab">here</a> 
-and for `PYTHON` <a href="https://github.com/dengwirda/jigsaw-python">here</a>.
+This package provides the underlying C++ source for JIGSAW; defining a
+basic command-line interface and a C-format API. A MATLAB / OCTAVE based
+scripting interface, including a range of additional facilities for file
+I/O, mesh visualisation and post-processing operations can be found at
+https://github.com/dengwirda/jigsaw-matlab.
 
 
 Current build status

--- a/README.md
+++ b/README.md
@@ -11,19 +11,21 @@ Summary: JIGSAW is a Delaunay-based unstructured mesh generator for two- and
 three-dimensional geometries.
 
 
-JIGSAW is a computational library for unstructured mesh generation and
-tessellation; designed to generate high-quality triangulations and
-polyhedral decompositions of general planar, surface and volumetric
-domains. JIGSAW includes refinement-based algorithms for the construction
+`JIGSAW` is an unstructured mesh generator and tessellation library;
+designed to generate high-quality triangulations and polyhedral
+decompositions of general planar, surface and volumetric domains.
+`JIGSAW` includes refinement-based algorithms for the construction
 of new meshes, optimisation-driven techniques for the improvement of
 existing grids, as well as routines to assemble (restricted) Delaunay
-tessellations and Voronoi complexes.
+tessellations, Voronoi complexes and Power diagrams.
 
-This package provides the underlying C++ source for JIGSAW; defining a
-basic command-line interface and a C-format API. A MATLAB / OCTAVE based
-scripting interface, including a range of additional facilities for file
-I/O, mesh visualisation and post-processing operations can be found at
-https://github.com/dengwirda/jigsaw-matlab.
+This package provides the underlying `c++` source for `JIGSAW`;
+defining a basic command-line interface and a `c`-format `API`.
+Higher-level scripting interfaces, supporting a range of additional
+facilities for file I/O, mesh visualisation and post-processing
+operations are also available, including for `MATLAB` / `OCTAVE`
+(https://github.com/dengwirda/jigsaw-matlab) and for `PYTHON`
+(https://github.com/dengwirda/jigsaw-python).
 
 
 Current build status

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ Summary: JIGSAW is a Delaunay-based unstructured mesh generator for two- and
 three-dimensional geometries.
 
 
-JIGSAW is a computational library for unstructured mesh generation and
-tessellation; designed to generate high-quality triangulations and
-polyhedral decompositions of general planar, surface and volumetric
-domains. JIGSAW includes refinement-based algorithms for the construction
-of new meshes, optimisation-driven techniques for the improvement of
-existing grids, as well as routines to assemble (restricted) Delaunay
-tessellations and Voronoi complexes.
+`JIGSAW` is an unstructured mesh generator and tessellation library; designed 
+to generate high-quality triangulations and polyhedral decompositions of general 
+planar, surface and volumetric domains. `JIGSAW` includes refinement-based 
+algorithms for the construction of new meshes, optimisation-driven techniques 
+for the improvement of existing grids, as well as routines to assemble 
+(restricted) Delaunay tessellations, Voronoi complexes and Power diagrams. 
 
-This package provides the underlying C++ source for JIGSAW; defining a
-basic command-line interface and a C-format API. A MATLAB / OCTAVE based
-scripting interface, including a range of additional facilities for file
-I/O, mesh visualisation and post-processing operations can be found at
-https://github.com/dengwirda/jigsaw-matlab.
+This package provides the underlying `c++` source for `JIGSAW`; defining a basic 
+command-line interface and a `c`-format `API`. Higher-level scripting interfaces, 
+supporting a range of additional facilities for file I/O, mesh visualisation and 
+post-processing operations are also available, including for 
+`MATLAB` / `OCTAVE` <a href="https://github.com/dengwirda/jigsaw-matlab">here</a> 
+and for `PYTHON` <a href="https://github.com/dengwirda/jigsaw-python">here</a>.
 
 
 Current build status

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,10 +27,15 @@ cd uni
 mkdir build
 cd build
 
+set CMAKE_FLAGS=-G "NMake Makefiles" ^
+                -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+                -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+                -DCMAKE_BUILD_TYPE=Debug
+
 cmake %CMAKE_FLAGS% ..
 if errorlevel 1 exit /b 1
 
-cmake --build . --config Release
+cmake --build . --config Debug
 if errorlevel 1 exit /b 1
 
 .\test_1.exe

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,7 @@ set -e
 # build and install JIGSAW
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=BUILD_MODE ..
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=Release ..
 cmake --build . --config Release --target install
 cd ..
 
@@ -14,8 +14,8 @@ cd ..
 cd uni
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=BUILD_MODE ..
-cmake --build . --config Release
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=Debug ..
+cmake --build . --config Debug
 for test in 1 2 3 4 5 6 7 8 9
 do
   ./test_${test}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f134baedcbfe02bac1fd6662a517b35f052a97abec1740073d0e34adf561d35d
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
 
 requirements:
@@ -35,19 +35,21 @@ about:
     JIGSAW is a Delaunay-based unstructured mesh generator for two- and
     three-dimensional geometries.
   description: |
-    JIGSAW is a computational library for unstructured mesh generation and
-    tessellation; designed to generate high-quality triangulations and
-    polyhedral decompositions of general planar, surface and volumetric
-    domains. JIGSAW includes refinement-based algorithms for the construction
-    of new meshes, optimisation-driven techniques for the improvement of
-    existing grids, as well as routines to assemble (restricted) Delaunay
-    tessellations and Voronoi complexes.
+    `JIGSAW` is an unstructured mesh generator and tessellation library; 
+    designed to generate high-quality triangulations and polyhedral 
+    decompositions of general planar, surface and volumetric domains. 
+    `JIGSAW` includes refinement-based algorithms for the construction 
+    of new meshes, optimisation-driven techniques for the improvement of 
+    existing grids, as well as routines to assemble (restricted) Delaunay 
+    tessellations, Voronoi complexes and Power diagrams. 
 
-    This package provides the underlying C++ source for JIGSAW; defining a
-    basic command-line interface and a C-format API. A MATLAB / OCTAVE based
-    scripting interface, including a range of additional facilities for file
-    I/O, mesh visualisation and post-processing operations can be found at
-    https://github.com/dengwirda/jigsaw-matlab.
+    This package provides the underlying `c++` source for `JIGSAW`; 
+    defining a basic command-line interface and a `c`-format `API`. 
+    Higher-level scripting interfaces, supporting a range of additional 
+    facilities for file I/O, mesh visualisation and post-processing 
+    operations are also available, including for `MATLAB` / `OCTAVE` 
+    (https://github.com/dengwirda/jigsaw-matlab) and for `PYTHON`
+    (https://github.com/dengwirda/jigsaw-python).
   doc_url: https://github.com/dengwirda/jigsaw
   dev_url: https://github.com/dengwirda/jigsaw
 


### PR DESCRIPTION
@xylar I've updated the `cmake` flags here, to try to ensure the builds are consistently either `Release` or `Debug`.

I saw that `jigsaw-0.9.13` was able to throw an assertion, which I believe means there's some debug information being pushed through the build process somehow.

I've also set the unit test builds as `Debug`, just in case this can help catch any extra errors.

I've not done any of the version / build number + re-rendering steps below, as this should wait until jigsaw-0.9.13.1 is available (shortly!)

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
